### PR TITLE
Fix paths for conditional exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "module": "index.mjs",
   "exports": {
-    "import": "index.mjs",
-    "default": "index.js"
+    "import": "./index.mjs",
+    "default": "./index.js"
   },
   "files": [
     "index.mjs",


### PR DESCRIPTION
I updated my Node.js to the latest LTS which is `12.18.0` and apparently they unflagged ESM.
When I tried using this plugin, I got this error:

```
[!] Error: Invalid "exports" main target "index.js" defined in the package config /E:/project/node_modules/rollup-plugin-preserve-shebang\package.json; targets must start with "./"
```

According to the [docs](https://nodejs.org/docs/latest-v12.x/api/esm.html#esm_package_entry_points), `exports` takes precedence over `main` in `package.json`, so all people who use a version of Node.js with unflagged ESM will probably get this error.

I just changed the paths to include the dot. It worked for me when I monkey patched it in my project.