### PR TITLE
typing: ts types support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+import {Plugin} from 'rollup';
+
+export default function shebangPlugin(options: {shebang?: string} = {}): Plugin;

--- a/package.json
+++ b/package.json
@@ -4,13 +4,15 @@
   "description": "Automatically preserve a shebang in your entry file.",
   "main": "index.js",
   "module": "index.mjs",
+  "types": "index.d.ts",
   "exports": {
     "import": "./index.mjs",
     "default": "./index.js"
   },
   "files": [
     "index.mjs",
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "scripts": {
     "prepare": "cjyes",


### PR DESCRIPTION
encounter error when using preserve-shebang plugin with typescript.

```sh
(node:19282) UnhandledPromiseRejectionWarning: TSError: ⨯ Unable to compile TypeScript:
src/rollup-config.ts:4:21 - error TS7016: Could not find a declaration file for module 'rollup-plugin-preserve-shebang'. 'node_modules/rollup-plugin-preserve-shebang/index.js' implicitly has an 'any' type.
  Try `npm install @types/rollup-plugin-preserve-shebang` if it exists or add a new declaration (.d.ts) file containing `declare module 'rollup-plugin-preserve-shebang';`

4 import shebang from "rollup-plugin-preserve-shebang";
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

### Changes

* add ts decalaration file
