### PR TITLE
Support .cjs files imported with `@rollup/plugin-commonjs`

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -19,7 +19,9 @@ export default function shebangPlugin(options = {}) {
 			return { code, map: null };
 		},
 		renderChunk(code, chunk, { sourcemap }) {
-			let shebang = shebangs.get(chunk.facadeModuleId);
+			// ids ending with ?commonjs-entry are created by rollup-plugin-commonjs
+			let modId = chunk.facadeModuleId && chunk.facadeModuleId.replace(/\?commonjs-entry$/, "");
+			let shebang = shebangs.get(modId);
 			if (!shebang) return null;
 			const s = new MagicString(code);
 			s.prepend(`${options.shebang || shebang}\n`);


### PR DESCRIPTION
Add support for CommonJS files loaded with `@rollup/plugin-commonjs`.

If try to run rollup-plugin-preserve-shebang on a CommonJS file
(e.g. one that uses `const x = require("...");` syntax instead of
`import`),
[@rollup/plugin-commonjs](https://www.npmjs.com/package/@rollup/plugin-commonjs)
will append `?commonjs-entry` to the end of the id.

This means that `renderChunk()` will fail to add the shebang back to the file, since the `moduleId` is different. 

E.g. in `transform(code, modId)`, `modId = "...example.js"`
However, in `renderChunk()`,
`chunk.facadeModuleId = "...example.js?commonjs-entry"`.

In order to get the original module id, you need to remove `?commonjs-entry`.